### PR TITLE
Time disappearing for momentjs

### DIFF
--- a/src/dygraph-tickers.js
+++ b/src/dygraph-tickers.js
@@ -384,6 +384,9 @@ export var getDateAxis = function(start_time, end_time, granularity, opts, dg) {
   date_array[DateField.DATEFIELD_MS] = accessors.getMilliseconds(start_date);
 
   var start_date_offset = date_array[datefield] % step;
+  var long_months = [0,2,4,6,7,9];
+  var short_months = [3,5,8,10];
+  
   if (granularity == Granularity.WEEKLY) {
     // This will put the ticks on Sundays.
     start_date_offset = accessors.getDay(start_date);
@@ -437,6 +440,52 @@ export var getDateAxis = function(start_time, end_time, granularity, opts, dg) {
                    });
       }
       date_array[datefield] += step;
+      if (datefield == 3) {
+        if(date_array[datefield] > 24) {            
+            if (long_months.indexOf(date_array[1]) != -1) {//Months with 31 days except December
+                if (date_array[2]==31) {
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = 1;
+                    date_array[1]++;
+                } else {
+                  date_array[datefield] = date_array[datefield] % 24;
+                  date_array[2] = date_array[2] + 1;
+                }          
+            } else if (short_months.indexOf(date_array[1]) != -1) { //Months with 30 days
+                if (date_array[2]==30) {
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = 1;
+                    date_array[1]++;
+                } else {
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = date_array[2] + 1;
+                }
+            } else if (date_array[1] == 1) { //February
+                if (date_array[2]==29 && date_array[1]%4==0) { // leap year
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = 1;
+                    date_array[1]++;
+                } else if (date_array[2]==28) {
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = 1;
+                    date_array[1]++;
+                } else {
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = date_array[2] + 1;
+                }
+            } else if (date_array[1] == 11) {//December
+                if (date_array[2]==31) {
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = 1;
+                    date_array[1]++;
+                    date_array[0]++;
+                } else {
+                    date_array[datefield] = date_array[datefield] % 24;
+                    date_array[2] = date_array[2] + 1;                    
+                } 
+            }
+        }        
+      }
       tick_date = accessors.makeDate.apply(null, date_array);
       tick_time = tick_date.getTime();
     }


### PR DESCRIPTION
This is a fix for the time disappearing on x-axis when momentjs and moment-timezone are used. This happened because Dygraphs uses hours in the form 0-23 for current day, then 24,25,26... for the next day. Parsing the hour in a such a format led to a conflict when used with momentjs and moment timezone for parsing time. What I have done is simply modified it to return 0-23 for hours and handle the corresponding changes for day, month and year changes. Note, that the bug was only for x-axis dates at the bottom and not on the hover of the line.
